### PR TITLE
test: sign up + refacto + add helpers

### DIFF
--- a/server/src/__tests__/helpers.ts
+++ b/server/src/__tests__/helpers.ts
@@ -1,0 +1,49 @@
+import Avatar from "../entities/Avatar";
+import User from "../entities/User";
+
+export const createMockAvatar = ({
+  id,
+  title,
+  image,
+  users,
+}: {
+  id?: number;
+  title?: string;
+  image?: string;
+  users?: User[];
+} = {}): Avatar => {
+  const avatar = new Avatar();
+  avatar.id = id ?? 1;
+  avatar.title = title ?? "Default Avatar";
+  avatar.image = image ?? "avatar.jpg";
+  avatar.users = users ?? [];
+  return avatar;
+};
+
+export const createMockUser = ({
+  id,
+  email,
+  first_name,
+  last_name,
+  birthdate,
+  hashed_password,
+  avatar,
+}: {
+  id?: number;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  birthdate?: Date;
+  hashed_password?: string;
+  avatar?: Avatar;
+} = {}): User => {
+  const user = new User();
+  user.id = id ?? 1;
+  user.email = email ?? "test@example.com";
+  user.first_name = first_name ?? "Jane";
+  user.last_name = last_name ?? "Doe";
+  user.birthdate = birthdate ?? new Date("1990-08-04");
+  user.hashed_password = hashed_password ?? "hashedPassword123";
+  user.avatar = avatar ?? createMockAvatar();
+  return user;
+};

--- a/server/src/resolvers/UserResolver.ts
+++ b/server/src/resolvers/UserResolver.ts
@@ -1,6 +1,14 @@
 import * as argon2 from "argon2";
 import * as jwt from "jsonwebtoken";
-import { Arg, Field, InputType, Int, Mutation, Query, Resolver } from "type-graphql";
+import {
+  Arg,
+  Field,
+  InputType,
+  Int,
+  Mutation,
+  Query,
+  Resolver,
+} from "type-graphql";
 
 import { AvatarInput } from "./AvatarResolver";
 import User from "../entities/User";
@@ -123,18 +131,18 @@ export default class UserResolver {
     try {
       if (!process.env.JWT_SECRET)
         throw new Error("Missing env variable: JWT_SECRET");
-  
+
       const user = await this.userService.authenticateUser(
         userData.email,
         userData.password
       );
-  
+
       if (!user) {
         throw new Error("Incorrect email or password");
       }
-  
+
       const token = jwt.sign(getUserTokenContent(user), process.env.JWT_SECRET);
-  
+
       return `${JSON.stringify(getUserPublicProfile(user))}; token=${token}`;
     } catch (err) {
       console.error(err);
@@ -142,4 +150,3 @@ export default class UserResolver {
     }
   }
 }
-

--- a/server/src/resolvers/__tests__/UserResolver.test.ts
+++ b/server/src/resolvers/__tests__/UserResolver.test.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import * as jwt from "jsonwebtoken";
-import UserResolver from '../UserResolver';
-import type { UserServiceInterface } from '../../services/UserService';
-import User from '../../entities/User';
 
-jest.mock('jsonwebtoken', () => ({
-  sign: jest.fn().mockReturnValue('mock-token'),
+import UserResolver from "../UserResolver";
+import { createMockUser, createMockAvatar } from "../../__tests__/helpers";
+
+import type User from "../../entities/User";
+import type { UserServiceInterface } from "../../services/UserService";
+
+jest.mock("jsonwebtoken", () => ({
+  sign: jest.fn().mockReturnValue("mock-token"),
+}));
+
+jest.mock("argon2", () => ({
+  hash: jest.fn(),
 }));
 
 // Mock UserService
@@ -15,42 +22,34 @@ const mockUserService: jest.Mocked<UserServiceInterface> = {
   authenticateUser: jest.fn(),
 };
 
-describe('UserResolver', () => {
+describe("UserResolver", () => {
   let userResolver: UserResolver;
   let mockUser: User;
 
   beforeEach(() => {
     // Reset environment
-    process.env.JWT_SECRET = 'test-secret-key';
-    
-    // Create resolver with mocked service
-    userResolver = new UserResolver(mockUserService);
-    
-    // Mock user data
-    mockUser = {
-      id: 1,
-      email: 'test@example.com',
-      first_name: 'Jane',
-      last_name: 'Doe',
-      birthdate: new Date('1990-08-04'),
-      hashed_password: 'hashedPassword123',
-      avatar: { id: 1, url: 'avatar.jpg' },
-      activities: [],
-    } as unknown as User;
-
-    // Clear all mocks
     jest.clearAllMocks();
+    process.env.JWT_SECRET = "test-secret-key";
+
+    // Mock data and functions
+    userResolver = new UserResolver(mockUserService);
+    mockUser = createMockUser();
+
+    const mockArgon2 = jest.mocked(require("argon2"));
+    mockArgon2.hash.mockResolvedValue(
+      "$argon2id$v=19$m=65536,t=3,p=4$hashedPassword"
+    );
   });
 
-  describe('login', () => {
-    it('should return token and user data with valid credentials', async () => {
+  describe("login", () => {
+    it("should return token and user data with valid credentials", async () => {
       // Arrange
       const userData = {
-        email: 'test@example.com',
-        password: 'validPassword123',
+        email: "test@example.com",
+        password: "validPassword123",
       };
-      const mockToken = 'mock-jwt-token';
-      
+      const mockToken = "mock-jwt-token";
+
       mockUserService.authenticateUser.mockResolvedValue(mockUser);
       (jwt.sign as jest.Mock).mockReturnValue(mockToken);
 
@@ -73,7 +72,7 @@ describe('UserResolver', () => {
         },
         process.env.JWT_SECRET
       );
-      expect(result).toContain('token=mock-jwt-token');
+      expect(result).toContain("token=mock-jwt-token");
       expect(result).toContain('"id":1');
       expect(result).toContain('"firstName":"Jane"');
     });
@@ -82,77 +81,253 @@ describe('UserResolver', () => {
       // Arrange
       delete process.env.JWT_SECRET;
       const userData = {
-        email: 'test@example.com',
-        password: 'validPassword123',
+        email: "test@example.com",
+        password: "validPassword123",
       };
 
       // Act & Assert
-      await expect(userResolver.login(userData))
-        .rejects
-        .toThrow('Login error');
+      await expect(userResolver.login(userData)).rejects.toThrow("Login error");
     });
 
     it('should throw "Login error" when user is not found', async () => {
       // Arrange
       const userData = {
-        email: 'nonexistent@example.com',
-        password: 'anyPassword123',
+        email: "nonexistent@example.com",
+        password: "anyPassword123",
       };
-      
-      mockUserService.authenticateUser.mockRejectedValue(new Error('User not found'));
+
+      mockUserService.authenticateUser.mockRejectedValue(
+        new Error("User not found")
+      );
 
       // Act & Assert
-      await expect(userResolver.login(userData))
-        .rejects
-        .toThrow('Login error');
+      await expect(userResolver.login(userData)).rejects.toThrow("Login error");
     });
 
     it('should throw "Login error" when password is invalid', async () => {
       // Arrange
       const userData = {
-        email: 'test@example.com',
-        password: 'wrongPassword123',
+        email: "test@example.com",
+        password: "wrongPassword123",
       };
-      
-      mockUserService.authenticateUser.mockRejectedValue(new Error('Invalid password'));
+
+      mockUserService.authenticateUser.mockRejectedValue(
+        new Error("Invalid password")
+      );
 
       // Act & Assert
-      await expect(userResolver.login(userData))
-        .rejects
-        .toThrow('Login error');
+      await expect(userResolver.login(userData)).rejects.toThrow("Login error");
     });
 
     it('should throw "Login error" when JWT signing fails', async () => {
       // Arrange
       const userData = {
-        email: 'test@example.com',
-        password: 'validPassword123',
+        email: "test@example.com",
+        password: "validPassword123",
       };
-      
+
       mockUserService.authenticateUser.mockResolvedValue(mockUser);
       (jwt.sign as jest.Mock).mockImplementation(() => {
-        throw new Error('JWT signing failed');
+        throw new Error("JWT signing failed");
       });
 
       // Act & Assert
-      await expect(userResolver.login(userData))
-        .rejects
-        .toThrow('Login error');
+      await expect(userResolver.login(userData)).rejects.toThrow("Login error");
     });
 
     it('should throw "Login error" when user is null', async () => {
       // Arrange
       const userData = {
-        email: 'test@example.com',
-        password: 'validPassword123',
+        email: "test@example.com",
+        password: "validPassword123",
       };
-      
+
       mockUserService.authenticateUser.mockResolvedValue(null);
 
       // Act & Assert
-      await expect(userResolver.login(userData))
-        .rejects
-        .toThrow('Login error');
+      await expect(userResolver.login(userData)).rejects.toThrow("Login error");
     });
+  });
+
+  describe("signup", () => {
+    const newUserData = {
+      email: "newuser@example.com",
+      password: "password123",
+      first_name: "John",
+      last_name: "Smith",
+      birthdate: new Date("1995-06-15"),
+      avatar: { id: 2, title: "New Avatar", image: "new-avatar.jpg" },
+    };
+
+    it("should create a new user and return profile with token", async () => {
+      // Arrange
+
+      const mockToken = "mock-signup-token";
+      const createdUser = createMockUser({
+        id: 2,
+        email: newUserData.email,
+        first_name: newUserData.first_name,
+        last_name: newUserData.last_name,
+        birthdate: newUserData.birthdate,
+        avatar: createMockAvatar({
+          id: newUserData.avatar.id,
+          title: newUserData.avatar.title,
+          image: newUserData.avatar.image,
+        }),
+      });
+
+      mockUserService.create.mockResolvedValue(createdUser);
+      (jwt.sign as jest.Mock).mockReturnValue(mockToken);
+
+      // Act
+      const result = await userResolver.signup(newUserData);
+
+      // Assert
+      expect(result).toContain("token=mock-signup-token");
+
+      // Assert service call
+      expect(mockUserService.create).toHaveBeenCalledWith({
+        ...newUserData,
+        password: expect.any(String),
+      });
+      expect(jwt.sign).toHaveBeenCalledWith(
+        {
+          id: createdUser.id,
+          firstName: createdUser.first_name,
+          lastName: createdUser.last_name,
+          mail: createdUser.email,
+          birthDate: createdUser.birthdate,
+          avatar: createdUser.avatar,
+        },
+        process.env.JWT_SECRET
+      );
+    });
+
+    it("should throw error when JWT_SECRET is missing during signup", async () => {
+      // Arrange
+      delete process.env.JWT_SECRET;
+
+      // Act
+      const result = await userResolver.signup(newUserData);
+
+      // Assert
+      expect(result).toBeInstanceOf(Error);
+      expect((result as Error).message).toContain(
+        "Missing env variable: JWT_SECRET"
+      );
+    });
+
+    it("should handle user creation errors", async () => {
+      // Arrange
+
+      mockUserService.create.mockRejectedValue(
+        new Error("Email already exists")
+      );
+
+      // Act
+      const result = await userResolver.signup(newUserData);
+
+      // Assert
+      expect(result).toBeInstanceOf(Error);
+      expect((result as Error).message).toBe("Email already exists");
+    });
+
+    it("should hash the password before creating user", async () => {
+      // Arrange
+      const createdUser = createMockUser({
+        email: newUserData.email,
+      });
+
+      mockUserService.create.mockResolvedValue(createdUser);
+
+      // Act
+      await userResolver.signup(newUserData);
+
+      // Assert
+      const createCall = mockUserService.create.mock.calls[0][0];
+      expect(createCall.password).not.toBe("plainTextPassword");
+      expect(createCall.password).toBeDefined();
+      expect(typeof createCall.password).toBe("string");
+    });
+
+    it("should include all required fields when creating user", async () => {
+      // Arrange
+      const newUserData = {
+        email: "complete@example.com",
+        password: "password123",
+        first_name: "Complete",
+        last_name: "User",
+        birthdate: new Date("1990-01-01"),
+        avatar: { id: 3, title: "Complete Avatar", image: "complete.jpg" },
+      };
+      const createdUser = createMockUser({
+        email: newUserData.email,
+        avatar: createMockAvatar({
+          id: newUserData.avatar.id,
+          title: newUserData.avatar.title,
+          image: newUserData.avatar.image,
+        }),
+      });
+
+      mockUserService.create.mockResolvedValue(createdUser);
+
+      // Act
+      await userResolver.signup(newUserData);
+
+      // Assert
+      const createCall = mockUserService.create.mock.calls[0][0];
+      expect(createCall).toEqual({
+        email: newUserData.email,
+        password: expect.any(String), // hashed password
+        first_name: newUserData.first_name,
+        last_name: newUserData.last_name,
+        birthdate: newUserData.birthdate,
+        avatar: newUserData.avatar,
+      });
+    });
+  });
+
+  it("should handle malformed email in signup", async () => {
+    // Arrange
+    const newUserDataFail = {
+      email: "invalid-email",
+      password: "password123",
+      first_name: "John",
+      last_name: "Smith",
+      birthdate: new Date("1995-06-15"),
+      avatar: { id: 2, title: "New Avatar", image: "new-avatar.jpg" },
+    };
+
+    mockUserService.create.mockRejectedValue(new Error("Invalid email format"));
+
+    // Act
+    const result = await userResolver.signup(newUserDataFail);
+
+    // Assert
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toBe("Invalid email format");
+  });
+
+  it("should handle user with existing email in signup", async () => {
+    // Arrange
+    const newUserDataFail = {
+      email: "existing@example.com",
+      password: "password123",
+      first_name: "John",
+      last_name: "Smith",
+      birthdate: new Date("1995-06-15"),
+      avatar: { id: 2, title: "New Avatar", image: "new-avatar.jpg" },
+    };
+
+    mockUserService.create.mockRejectedValue(
+      new Error("UNIQUE constraint failed: user.email")
+    );
+
+    // Act
+    const result = await userResolver.signup(newUserDataFail);
+
+    // Assert
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toContain("UNIQUE constraint failed");
   });
 });

--- a/server/src/services/__tests__/UserService.test.ts
+++ b/server/src/services/__tests__/UserService.test.ts
@@ -1,163 +1,174 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import UserService from '../UserService';
-import User from '../../entities/User';
 
-jest.mock('argon2', () => ({
+import UserService from "../UserService";
+import { createMockUser } from "../../__tests__/helpers";
+
+import type User from "../../entities/User";
+
+jest.mock("argon2", () => ({
   verify: jest.fn(),
 }));
 
-jest.mock('../../entities/User', () => ({
-  findOne: jest.fn(),
-}));
+// Mock des entités avec les méthodes statiques et constructeurs
+jest.mock("../../entities/User", () => {
+  return jest.fn().mockImplementation(() => ({
+    id: 1,
+    email: "test@example.com",
+    first_name: "Jane",
+    last_name: "Doe",
+    birthdate: new Date("1990-08-04"),
+    hashed_password: "hashedPassword123",
+    avatar: null,
+    activities: [],
+    sentFriendRequests: [],
+    receivedFriendRequests: [],
+    interactions: [],
+  }));
+});
 
-describe('UserService', () => {
+jest.mock("../../entities/Avatar", () => {
+  return jest.fn().mockImplementation(() => ({
+    id: 1,
+    title: "Default Avatar",
+    image: "avatar.jpg",
+    users: [],
+  }));
+});
+
+// Mock des méthodes statiques après la définition des mocks
+const MockedUser = jest.mocked(require("../../entities/User"));
+MockedUser.findOne = jest.fn();
+
+describe("UserService", () => {
   let userService: UserService;
   let mockUser: User;
-  // biome-ignore lint/suspicious/noImplicitAnyLet:
-  let argon2;
-  // biome-ignore lint/suspicious/noImplicitAnyLet:
-  let User;
 
-  beforeEach(async () => {
+  beforeEach(() => {
+    // Create service instance
+    userService = new UserService();
 
-    const UserServiceModule = await import('../UserService');
-    const UserModule = await import('../../entities/User');
-    const argon2Module = await import('argon2');
-    
-    userService = new UserServiceModule.default();
-    User = UserModule.default;
-    argon2 = argon2Module;
-    
+    // Create mock user using helper
+    mockUser = createMockUser({
+      email: "test@example.com",
+      hashed_password: "hashedPassword123",
+    });
 
-    mockUser = {
-      id: 1,
-      email: 'test@example.com',
-      hashed_password: 'hashedPassword123',
-      first_name: 'Jane',
-      last_name: 'Doe',
-      birthdate: new Date('1990-08-04'),
-      avatar: null,
-      activities: [],
-    } as unknown as User;
-
+    // Clear all mocks
     jest.clearAllMocks();
   });
 
-  describe('findByEmail', () => {
-    it('should return user when email exists', async () => {
+  describe("findByEmail", () => {
+    it("should return user when email exists", async () => {
       // Arrange
-      const email = 'test@example.com';
-      User.findOne.mockResolvedValue(mockUser);
+      const email = "test@example.com";
+      MockedUser.findOne.mockResolvedValue(mockUser);
 
       // Act
       const result = await userService.findByEmail(email);
 
       // Assert
-      expect(User.findOne).toHaveBeenCalledWith({
+      expect(MockedUser.findOne).toHaveBeenCalledWith({
         where: { email },
-        relations: ['avatar']
+        relations: ["avatar"],
       });
       expect(result).toEqual(mockUser);
     });
 
-    it('should return null when email does not exist', async () => {
+    it("should return null when email does not exist", async () => {
       // Arrange
-      const email = 'nonexistent@example.com';
-      User.findOne.mockResolvedValue(null);
+      const email = "nonexistent@example.com";
+      MockedUser.findOne.mockResolvedValue(null);
 
       // Act
       const result = await userService.findByEmail(email);
 
       // Assert
-      expect(User.findOne).toHaveBeenCalledWith({
+      expect(MockedUser.findOne).toHaveBeenCalledWith({
         where: { email },
-        relations: ['avatar']
+        relations: ["avatar"],
       });
       expect(result).toBeNull();
     });
 
-    it('should handle database errors', async () => {
+    it("should handle database errors", async () => {
       // Arrange
-      const email = 'test@example.com';
-      const dbError = new Error('Database connection failed');
-      User.findOne.mockRejectedValue(dbError);
+      const email = "test@example.com";
+      const dbError = new Error("Database connection failed");
+      MockedUser.findOne.mockRejectedValue(dbError);
 
       // Act & Assert
-      await expect(userService.findByEmail(email))
-        .rejects
-        .toThrow('Database connection failed');
+      await expect(userService.findByEmail(email)).rejects.toThrow(
+        "Database connection failed"
+      );
 
-      expect(User.findOne).toHaveBeenCalledWith({
+      expect(MockedUser.findOne).toHaveBeenCalledWith({
         where: { email },
-        relations: ['avatar']
+        relations: ["avatar"],
       });
     });
   });
 
-  describe('authenticateUser', () => {
-    it('should successfully authenticate user with valid credentials', async () => {
-      
-      const email = 'test@example.com';
-      const password = 'validPassword123';
-      
-      // Mock the database call
-      User.findOne.mockResolvedValue(mockUser);
-      
-      // Mock the password verification
-      argon2.verify.mockResolvedValue(true);
+  describe("authenticateUser", () => {
+    it("should successfully authenticate user with valid credentials", async () => {
+      const email = "test@example.com";
+      const password = "validPassword123";
+      const mockArgon2 = jest.mocked(require("argon2"));
+
+      MockedUser.findOne.mockResolvedValue(mockUser);
+      mockArgon2.verify.mockResolvedValue(true);
 
       // Act
       const result = await userService.authenticateUser(email, password);
 
       // Assert
-      expect(User.findOne).toHaveBeenCalledWith({
+      expect(MockedUser.findOne).toHaveBeenCalledWith({
         where: { email },
-        relations: ['avatar']
+        relations: ["avatar"],
       });
-      expect(argon2.verify).toHaveBeenCalledWith(mockUser.hashed_password, password);
+      expect(mockArgon2.verify).toHaveBeenCalledWith(
+        mockUser.hashed_password,
+        password
+      );
       expect(result).toEqual(mockUser);
     });
 
-    it('should throw error when user is not found', async () => {
-      
-      const email = 'nonexistent@example.com';
-      const password = 'anyPassword123';
-      
-      // Mock the database call to return null
-      User.findOne.mockResolvedValue(null);
+    it("should throw error when user is not found", async () => {
+      const email = "nonexistent@example.com";
+      const password = "anyPassword123";
+      MockedUser.findOne.mockResolvedValue(null);
 
       // Act & Assert
-      await expect(userService.authenticateUser(email, password))
-        .rejects
-        .toThrow('User not found');
+      await expect(
+        userService.authenticateUser(email, password)
+      ).rejects.toThrow("User not found");
 
-      expect(User.findOne).toHaveBeenCalledWith({
+      expect(MockedUser.findOne).toHaveBeenCalledWith({
         where: { email },
-        relations: ['avatar']
+        relations: ["avatar"],
       });
     });
 
-    it('should throw error when password is invalid', async () => {
-      
-      const email = 'test@example.com';
-      const password = 'wrongPassword123';
-      
-      
-      User.findOne.mockResolvedValue(mockUser);
-      
-      // Mock the password verification to return false
-      argon2.verify.mockResolvedValue(false);
+    it("should throw error when password is invalid", async () => {
+      const email = "test@example.com";
+      const password = "wrongPassword123";
+      const mockArgon2 = jest.mocked(require("argon2"));
+
+      MockedUser.findOne.mockResolvedValue(mockUser);
+      mockArgon2.verify.mockResolvedValue(false);
 
       // Act & Assert
-      await expect(userService.authenticateUser(email, password))
-        .rejects
-        .toThrow('Invalid password');
+      await expect(
+        userService.authenticateUser(email, password)
+      ).rejects.toThrow("Invalid password");
 
-      expect(User.findOne).toHaveBeenCalledWith({
+      expect(MockedUser.findOne).toHaveBeenCalledWith({
         where: { email },
-        relations: ['avatar']
+        relations: ["avatar"],
       });
-      expect(argon2.verify).toHaveBeenCalledWith(mockUser.hashed_password, password);
+      expect(mockArgon2.verify).toHaveBeenCalledWith(
+        mockUser.hashed_password,
+        password
+      );
     });
   });
-}); 
+});


### PR DESCRIPTION
## Description
Ajout des tests liés au sign up côté server et optimisation des tests côté serveur de manière générale notamment avec la suppression des type assertions et création de helpers centralisés pour mocker les données.

## Changes Made
> Details changes you made

**feat**: Ajout de fonctions helper centralisées pour la création d'objets mock
**fix**: Suppression des assertions "as unknown as User" dans les tests
**refactor**: 
- Refactorisation des tests UserResolver & UserService
**test**: 
- Tests liés au sign up dans le UserResolver 

## How to test ? 
> Provide steps to test or validate the changes.
- [ ] Exécuter `npm test` dans le dossier server