### PR TITLE
feat: implement login form with authentication service +  tests

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -8,6 +8,8 @@ import App from "./App";
 import ModeProvider from "./context/modeContext";
 
 import SignUp from "./pages/signUp/SignUp";
+import Login from "./pages/login/Login";
+import Dashboard from "./pages/dashboard/Dashboard";
 import TestCharte from "./pages/testsCharte/TestsCharte";
 
 import "./reset.css";
@@ -27,7 +29,11 @@ const router = createBrowserRouter([
       },
       {
         path: "login",
-        element: <p>This is login, i don't exist yet.</p>,
+        element: <Login />,
+      },
+      {
+        path: "dashboard",
+        element: <Dashboard />,
       },
       {
         path: "/charte",

--- a/client/src/pages/dashboard/Dashboard.module.scss
+++ b/client/src/pages/dashboard/Dashboard.module.scss
@@ -1,0 +1,10 @@
+// TODO: Implement styles for dashboard
+.dashboard {
+  &--light {
+    
+  }
+
+  &--dark {
+    
+  }
+}

--- a/client/src/pages/dashboard/Dashboard.tsx
+++ b/client/src/pages/dashboard/Dashboard.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { getToken, removeToken } from "../../services/authService";
+
+export default function Dashboard() {
+  useEffect(() => {
+    // Check if user has token, redirect to login if not
+    const token = getToken();
+    if (!token) {
+      window.location.href = "/login";
+    }
+  }, []);
+
+  const handleLogout = () => {
+    removeToken();
+    window.location.href = "/login";
+  };
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <button onClick={handleLogout}>Logout</button>
+    </div>
+  );
+}

--- a/client/src/pages/login/Login.module.scss
+++ b/client/src/pages/login/Login.module.scss
@@ -1,0 +1,11 @@
+// TODO: Implement styles for light and dark modes
+
+.login {
+  &--light {
+
+  }
+
+  &--dark {
+    
+  }
+}

--- a/client/src/pages/login/Login.tsx
+++ b/client/src/pages/login/Login.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { login, saveToken, parseLoginResponse } from "../../services/authService";
+
+// TODO: Implement styles
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    
+    try {
+      const result = await login(email, password);
+      console.log("Login successful:", result);
+      
+      const { token } = parseLoginResponse(result);
+      
+      saveToken(token);
+      
+      navigate("/dashboard");
+    } catch (error) {
+      setError("Login failed. Please check your credentials and try again.");
+      console.error("Login error:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+  
+
+  return (
+    <section className="">
+      <div
+        className=""
+      >
+        <h1 className="">
+          Bienvenue !
+        </h1>
+
+        <h2 className="">
+          Qu'est-ce que footsy ?
+        </h2>
+        <p className="">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eu turpis ut metus luctus fringilla. Integer ac elit ut nisl volutpat tempus pretium ut metus.
+        </p>
+        <h2 className="">
+          Se connecter
+        </h2>
+
+        <form onSubmit={handleSubmit}>
+          {error && <div style={{ color: "red", marginBottom: "10px" }}>{error}</div>}
+          
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          
+          <input
+            type="password"
+            placeholder="Mot de passe"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          
+          <button type="submit" disabled={loading}>
+            {loading ? "Connexion..." : "Connexion"}
+          </button>
+        </form>
+
+        <div className="">
+          <Link
+            to="/signup"
+            className=""
+          >
+            Vous n'avez pas de compte ? Inscrivez-vous ici !      
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/services/__tests__/authService.test.ts
+++ b/client/src/services/__tests__/authService.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, type MockedFunction } from 'vitest';
+import { login, parseLoginResponse, saveToken, getToken, removeToken } from '../authService';
+
+
+interface GraphQLResponse {
+  data?: {
+    login: string;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+// Mock fetch globally
+const mockFetch = vi.fn() as MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: vi.fn() as MockedFunction<Storage['getItem']>,
+  setItem: vi.fn() as MockedFunction<Storage['setItem']>,
+  removeItem: vi.fn() as MockedFunction<Storage['removeItem']>,
+  clear: vi.fn() as MockedFunction<Storage['clear']>,
+};
+
+// Override global localStorage with mock
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
+describe('authService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    localStorage.clear();
+  });
+
+  describe('parseLoginResponse', () => {
+    it('should parse valid login response correctly', () => {
+      const mockResponse = '{"id":1,"firstName":"John","lastName":"Doe","mail":"john@example.com"}; token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...';
+      
+      const result = parseLoginResponse(mockResponse);
+      
+      expect(result).toEqual({
+        user: {
+          id: 1,
+          firstName: "John",
+          lastName: "Doe",
+          mail: "john@example.com"
+        },
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+      });
+    });
+
+    it('should throw error for invalid response format', () => {
+      const invalidResponse = 'invalid-format';
+      
+      expect(() => parseLoginResponse(invalidResponse)).toThrow('Failed to parse login response');
+    });
+
+    it('should throw error for malformed JSON', () => {
+      const malformedResponse = 'invalid-json; token=some-token';
+      
+      expect(() => parseLoginResponse(malformedResponse)).toThrow('Failed to parse login response');
+    });
+  });
+
+  describe('token management', () => {
+    it('should save and retrieve token from localStorage', () => {
+      const testToken = 'test-token-123';
+      
+      saveToken(testToken);
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('token', testToken);
+      
+      localStorageMock.getItem.mockReturnValue(testToken);
+      const retrievedToken = getToken();
+      expect(localStorageMock.getItem).toHaveBeenCalledWith('token');
+      expect(retrievedToken).toBe(testToken);
+    });
+
+    it('should remove token from localStorage', () => {
+      const testToken = 'test-token-123';
+      
+      localStorageMock.getItem.mockReturnValue(testToken);
+      expect(getToken()).toBe(testToken);
+      
+      removeToken();
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('token');
+    });
+
+    it('should return null when no token exists', () => {
+      localStorageMock.getItem.mockReturnValue(null);
+      expect(getToken()).toBeNull();
+    });
+  });
+
+  describe('login function', () => {
+    it('should make successful login request', async () => {
+      const mockResponse: GraphQLResponse = {
+        data: {
+          login: '{"id":1,"firstName":"John","lastName":"Doe","mail":"john@example.com"}; token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+        }
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      const result = await login('john@example.com', 'password123');
+
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:5050/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: `
+          mutation Login($data: UserInput!) {
+            login(data: $data)
+          }
+        `,
+          variables: {
+            data: {
+              email: 'john@example.com',
+              password: 'password123',
+            },
+          },
+        }),
+      });
+
+      expect(result).toBe(mockResponse.data?.login);
+    });
+
+    it('should throw error when login fails', async () => {
+      const mockError: GraphQLResponse = {
+        errors: [{ message: 'Invalid credentials' }]
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve(mockError),
+      } as Response);
+
+      await expect(login('invalid@example.com', 'wrongpassword')).rejects.toThrow('Login failed');
+    });
+
+    it('should throw error when network request fails', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(login('john@example.com', 'password123')).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('integration test', () => {
+    it('should complete full login flow', async () => {
+      const mockResponse: GraphQLResponse = {
+        data: {
+          login: '{"id":1,"firstName":"John","lastName":"Doe","mail":"john@example.com"}; token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'
+        }
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve(mockResponse),
+      } as Response);
+
+      // Test the full flow
+      const loginResult = await login('john@example.com', 'password123');
+      const { user, token } = parseLoginResponse(loginResult);
+      
+      saveToken(token);
+
+      // Verify everything worked
+      expect(user.firstName).toBe('John');
+      expect(user.lastName).toBe('Doe');
+      expect(user.mail).toBe('john@example.com');
+      
+      // Mock the getItem to return the token saved
+      localStorageMock.getItem.mockReturnValue('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
+      expect(getToken()).toBe('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
+    });
+  });
+});

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -1,0 +1,72 @@
+const API_URL = "http://localhost:5050/graphql";
+
+export const login = async (email: string, password: string) => {
+  try {
+    const response = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: `
+          mutation Login($data: UserInput!) {
+            login(data: $data)
+          }
+        `,
+        variables: {
+          data: {
+            email,
+            password,
+          },
+        },
+      }),
+    });
+
+    const result = await response.json();
+
+    if (result.errors) {
+      throw new Error("Login failed");
+    }
+
+    return result.data.login;
+  } catch (error) {
+    console.error("Login error:", error);
+    throw error;
+  }
+};
+
+export const parseLoginResponse = (response: string) => {
+  try {
+    // Split by "; token=" to separate user data and token
+    const parts = response.split("; token=");
+    if (parts.length !== 2) {
+      throw new Error("Invalid response format");
+    }
+    
+    const userData = parts[0];
+    const token = parts[1];
+    
+    // Parse user data (it's JSON stringified)
+    const user = JSON.parse(userData);
+    
+    return {
+      user,
+      token
+    };
+  } catch (error) {
+    console.error("Error parsing login response:", error);
+    throw new Error("Failed to parse login response");
+  }
+};
+
+export const saveToken = (token: string) => {
+  localStorage.setItem("token", token);
+};
+
+export const getToken = () => {
+  return localStorage.getItem("token");
+};
+
+export const removeToken = () => {
+  localStorage.removeItem("token");
+};


### PR DESCRIPTION
## Description
feat: implement login form with authentication service

## Changes Made
- Added login page with form validation and error handling
- Implemented auth service with GraphQL integration
- Added token management utilities
- Configured routing for login page

## Technical Implementation
- Login form with email/password inputs
- GraphQL mutation for authentication
- localStorage for token persistence
- Automatic redirect to dashboard on success
- Loading states and error messages

## Files
- `pages/login/Login.tsx`
- `services/authService.ts`
- `main.tsx` (routing)

## How to test ? 
- [ ]  npm test