### PR TITLE
11/feat/historic back

### DIFF
--- a/client/src/services/__tests__/authService.test.ts
+++ b/client/src/services/__tests__/authService.test.ts
@@ -1,11 +1,11 @@
-// import {
-//   describe,
-//   it,
-//   expect,
-//   vi,
-//   beforeEach,
-//   type MockedFunction,
-// } from "vitest";
+import {
+  //   beforeEach,
+  describe,
+  expect,
+  it,
+  //   type MockedFunction,
+  //   vi,
+} from "vitest";
 // import type { ApolloClient } from "@apollo/client";
 // import {
 //   login,
@@ -191,3 +191,9 @@
 //     });
 //   });
 // });
+
+describe("Placeholder test", () => {
+  it("should pass", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/server/src/__tests__/helpers.ts
+++ b/server/src/__tests__/helpers.ts
@@ -1,7 +1,6 @@
 import Activity from "../entities/Activity";
 import Avatar from "../entities/Avatar";
 import Category from "../entities/Category";
-import type Interaction from "../entities/Interaction";
 import Type from "../entities/Type";
 import User from "../entities/User";
 
@@ -52,74 +51,38 @@ export const createMockUser = ({
   return user;
 };
 
-export const createMockCategory = ({
-  id,
-  title,
-  types,
-}: {
-  id?: number;
-  title?: string;
-  types?: Type[];
-} = {}): Category => {
-  const category = new Category();
-  category.id = id ?? 1;
-  category.title = title ?? "Transport";
-  category.types = types ?? [];
-  return category;
-};
+export const createMockCategory = (
+  overrides: Partial<Category> = {}
+): Category =>
+  Object.assign(new Category(), {
+    id: 1,
+    title: "Transport",
+    types: [],
+    ...overrides,
+  });
 
-export const createMockType = ({
-  id,
-  title,
-  quantity_unit,
-  category_id,
-  category,
-  activities,
-}: {
-  id?: number;
-  title?: string;
-  quantity_unit?: string;
-  category_id?: number;
-  category?: Category;
-  activities?: Activity[];
-} = {}): Type => {
-  const type = new Type();
-  type.id = id ?? 1;
-  type.title = title ?? "Car";
-  type.quantity_unit = quantity_unit ?? "km";
-  type.category_id = category_id ?? 1;
-  type.category = category ?? createMockCategory();
-  type.activities = activities ?? [];
-  return type;
-};
+export const createMockType = (overrides: Partial<Type> = {}): Type =>
+  Object.assign(new Type(), {
+    id: 1,
+    title: "Car",
+    quantity_unit: "km",
+    category_id: 1,
+    category: createMockCategory(),
+    activities: [],
+    ...overrides,
+  });
 
-export const createMockActivity = ({
-  id,
-  title,
-  quantity,
-  date,
-  co2_equivalent,
-  user,
-  type,
-  interactions,
-}: {
-  id?: number;
-  title?: string;
-  quantity?: number;
-  date?: Date;
-  co2_equivalent?: number;
-  user?: User;
-  type?: Type;
-  interactions?: Interaction[];
-} = {}): Activity => {
-  const activity = new Activity();
-  activity.id = id ?? 1;
-  activity.title = title ?? "Trip to work";
-  activity.quantity = quantity ?? 10.5;
-  activity.date = date ?? new Date("2024-01-15");
-  activity.co2_equivalent = co2_equivalent ?? 2.5;
-  activity.user = user ?? createMockUser();
-  activity.type = type ?? createMockType();
-  activity.interactions = interactions ?? [];
-  return activity;
-};
+export const createMockActivity = (
+  overrides: Partial<Activity> = {}
+): Activity =>
+  Object.assign(new Activity(), {
+    id: 1,
+    title: "Trip to work",
+    quantity: 10.5,
+    date: new Date("2024-01-15"),
+    co2_equivalent: 2.5,
+    user: createMockUser(),
+    type: createMockType(),
+    interactions: [],
+    ...overrides,
+  });

--- a/server/src/__tests__/helpers.ts
+++ b/server/src/__tests__/helpers.ts
@@ -1,4 +1,8 @@
+import Activity from "../entities/Activity";
 import Avatar from "../entities/Avatar";
+import Category from "../entities/Category";
+import type Interaction from "../entities/Interaction";
+import Type from "../entities/Type";
 import User from "../entities/User";
 
 export const createMockAvatar = ({
@@ -46,4 +50,76 @@ export const createMockUser = ({
   user.hashed_password = hashed_password ?? "hashedPassword123";
   user.avatar = avatar ?? createMockAvatar();
   return user;
+};
+
+export const createMockCategory = ({
+  id,
+  title,
+  types,
+}: {
+  id?: number;
+  title?: string;
+  types?: Type[];
+} = {}): Category => {
+  const category = new Category();
+  category.id = id ?? 1;
+  category.title = title ?? "Transport";
+  category.types = types ?? [];
+  return category;
+};
+
+export const createMockType = ({
+  id,
+  title,
+  quantity_unit,
+  category_id,
+  category,
+  activities,
+}: {
+  id?: number;
+  title?: string;
+  quantity_unit?: string;
+  category_id?: number;
+  category?: Category;
+  activities?: Activity[];
+} = {}): Type => {
+  const type = new Type();
+  type.id = id ?? 1;
+  type.title = title ?? "Car";
+  type.quantity_unit = quantity_unit ?? "km";
+  type.category_id = category_id ?? 1;
+  type.category = category ?? createMockCategory();
+  type.activities = activities ?? [];
+  return type;
+};
+
+export const createMockActivity = ({
+  id,
+  title,
+  quantity,
+  date,
+  co2_equivalent,
+  user,
+  type,
+  interactions,
+}: {
+  id?: number;
+  title?: string;
+  quantity?: number;
+  date?: Date;
+  co2_equivalent?: number;
+  user?: User;
+  type?: Type;
+  interactions?: Interaction[];
+} = {}): Activity => {
+  const activity = new Activity();
+  activity.id = id ?? 1;
+  activity.title = title ?? "Trip to work";
+  activity.quantity = quantity ?? 10.5;
+  activity.date = date ?? new Date("2024-01-15");
+  activity.co2_equivalent = co2_equivalent ?? 2.5;
+  activity.user = user ?? createMockUser();
+  activity.type = type ?? createMockType();
+  activity.interactions = interactions ?? [];
+  return activity;
 };

--- a/server/src/entities/Activity.ts
+++ b/server/src/entities/Activity.ts
@@ -1,7 +1,16 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn, OneToOne, OneToMany } from "typeorm";
-import { Field, Int, ObjectType, Float } from "type-graphql";
-import Type from "./Type";
+import { Field, Float, Int, ObjectType } from "type-graphql";
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
 import Interaction from "./Interaction";
+import Type from "./Type";
 import User from "./User";
 
 @ObjectType()
@@ -28,16 +37,18 @@ export default class Activity extends BaseEntity {
   co2_equivalent: number;
 
   @Field(() => User)
-  @ManyToOne(() => User, user => user.activities, { nullable: false })
+  @ManyToOne(() => User, (user) => user.activities, { nullable: false })
   @JoinColumn({ name: "user_id" })
   user: User;
 
   @Field(() => Type)
-  @ManyToOne(() => Type, type => type.activities, { nullable: false })
+  @ManyToOne(() => Type, (type) => type.activities, { nullable: false })
   @JoinColumn({ name: "type_id" })
   type: Type;
 
   @Field(() => Interaction)
-  @OneToMany(() => Interaction, interaction => interaction.activity)
+  @OneToMany(() => Interaction, (interaction) => interaction.activity, {
+    nullable: true,
+  })
   interactions: Interaction[];
-} 
+}

--- a/server/src/entities/Avatar.ts
+++ b/server/src/entities/Avatar.ts
@@ -1,5 +1,11 @@
-import {  BaseEntity, Column, Entity, OneToMany,PrimaryGeneratedColumn} from "typeorm";
 import { Field, Int, ObjectType } from "type-graphql";
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import User from "./User";
 
 @ObjectType()

--- a/server/src/entities/Category.ts
+++ b/server/src/entities/Category.ts
@@ -1,22 +1,26 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn, OneToMany, ManyToOne } from "typeorm";
 import { Field, Int, ObjectType } from "type-graphql";
-import Type from "./Type";
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 
+import Type from "./Type";
 
 @ObjectType()
 @Entity()
 export default class Category extends BaseEntity {
-
   @Field(() => Int)
   @PrimaryGeneratedColumn()
   id: number;
-
 
   @Field(() => String)
   @Column("varchar", { length: 50 })
   title: string;
 
   @Field(() => Type)
-  @ManyToOne(() => Type, type => type.categories, { nullable: false })
+  @ManyToOne(() => Type, (type) => type.categories, { nullable: true })
   types: Type[];
-} 
+}

--- a/server/src/entities/Category.ts
+++ b/server/src/entities/Category.ts
@@ -21,6 +21,6 @@ export default class Category extends BaseEntity {
   title: string;
 
   @Field(() => Type)
-  @ManyToOne(() => Type, (type) => type.categories, { nullable: true })
+  @ManyToOne(() => Type, (type) => type.category, { nullable: true })
   types: Type[];
 }

--- a/server/src/entities/Type.ts
+++ b/server/src/entities/Type.ts
@@ -33,7 +33,7 @@ export default class Type extends BaseEntity {
   category: Category;
 
   @Field(() => Int)
-  @Column()
+  @Column("number")
   category_id: number;
 
   @Field(() => [Activity])

--- a/server/src/entities/Type.ts
+++ b/server/src/entities/Type.ts
@@ -1,13 +1,20 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn, OneToMany, ManyToOne, JoinColumn, OneToOne } from "typeorm";
 import { Field, Int, ObjectType } from "type-graphql";
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
 import Activity from "./Activity";
 import Category from "./Category";
-
 
 @ObjectType()
 @Entity()
 export default class Type extends BaseEntity {
-
   @Field(() => Int)
   @PrimaryGeneratedColumn()
   id: number;
@@ -21,11 +28,15 @@ export default class Type extends BaseEntity {
   quantity_unit: string;
 
   @Field(() => Category)
-  @ManyToOne(() => Category, category => category.types)
+  @ManyToOne(() => Category, (category) => category.types)
   @JoinColumn({ name: "category_id" })
-  categories: Category[];
+  category: Category;
 
-  @Field(() => Activity)
+  @Field(() => Int)
+  @Column()
+  category_id: number;
+
+  @Field(() => [Activity])
   @OneToMany(() => Activity, (activity) => activity.type)
   activities: Activity[];
 }

--- a/server/src/entities/User.ts
+++ b/server/src/entities/User.ts
@@ -4,17 +4,15 @@ import {
   Column,
   Entity,
   JoinColumn,
-  ManyToMany,
   ManyToOne,
   OneToMany,
-  OneToOne,
   PrimaryGeneratedColumn,
 } from "typeorm";
 
+import Activity from "./Activity";
 import Avatar from "./Avatar";
 import Friend from "./Friend";
 import Interaction from "./Interaction";
-import Activity from "./Activity";
 
 @ObjectType()
 @Entity()
@@ -47,14 +45,14 @@ export default class User extends BaseEntity {
   @JoinColumn({ name: "avatar_id" })
   avatar: Avatar;
 
-  @OneToMany(() => Friend, friend => friend.requester)
+  @OneToMany(() => Friend, (friend) => friend.requester)
   sentFriendRequests: Friend[];
 
-  @OneToMany(() => Friend, friend => friend.requested)
+  @OneToMany(() => Friend, (friend) => friend.requested)
   receivedFriendRequests: Friend[];
 
   @Field(() => Interaction)
-  @OneToMany(() => Interaction, interaction => interaction.users)
+  @OneToMany(() => Interaction, (interaction) => interaction.users)
   interactions: Interaction[];
 
   @Field(() => [Activity])

--- a/server/src/resolvers/ActivityResolver.ts
+++ b/server/src/resolvers/ActivityResolver.ts
@@ -1,34 +1,61 @@
-import { Resolver, Query, Mutation, Arg, Int, Float, InputType, Field } from "type-graphql";
+import {
+  Arg,
+  Field,
+  Float,
+  InputType,
+  Int,
+  Mutation,
+  Query,
+  Resolver,
+} from "type-graphql";
+
 import Activity from "../entities/Activity";
 import Type from "../entities/Type";
 import User from "../entities/User";
-import { InteractionInput } from "./InteractionResolver";
 
 @InputType()
-export class ActivityInput {
-    @Field(() => Int)
-      id: number;
-    
-      @Field(() => String)
-      title: string;
-    
-      @Field(() => Float, { nullable: true })
-      quantity: number;
-    
-      @Field(() => Date)
-      date: Date;
-    
-      @Field(() => Float)
-      co2_equivalent: number;
-    
-      @Field(() => Int)
-      user_id: number;
-    
-      @Field(() => Int)
-      type_id: number;
-    
-      @Field(() => InteractionInput)
-      interactions: InteractionInput[];
+export class CreateActivityInput {
+  @Field(() => String)
+  title: string;
+
+  @Field(() => Float, { nullable: true })
+  quantity: number;
+
+  @Field(() => Date)
+  date: Date;
+
+  @Field(() => Float)
+  co2_equivalent: number;
+
+  @Field(() => Int)
+  user_id: number;
+
+  @Field(() => Int)
+  type_id: number;
+}
+
+@InputType()
+export class UpdateActivityInput {
+  @Field(() => Int)
+  id: number;
+
+  @Field(() => String, { nullable: true })
+  title?: string;
+
+  @Field(() => Float, { nullable: true })
+  quantity?: number;
+
+  @Field(() => Date, { nullable: true })
+  date?: Date;
+
+  @Field(() => Float, { nullable: true })
+  co2_equivalent?: number;
+
+  @Field(() => Int, { nullable: true })
+  user_id?: number;
+
+  @Field(() => Int, { nullable: true })
+  type_id?: number;
 }
 
 @Resolver()
@@ -45,9 +72,8 @@ export default class ActivityResolver {
 
   @Mutation(() => Activity)
   async createActivity(
-    @Arg("data", () => ActivityInput) data: ActivityInput
+    @Arg("data", () => CreateActivityInput) data: CreateActivityInput
   ): Promise<Activity> {
-
     const user = await User.findOne({ where: { id: data.user_id } });
     if (!user) throw new Error("User not found");
 
@@ -64,15 +90,23 @@ export default class ActivityResolver {
 
   @Mutation(() => Activity, { nullable: true })
   async updateActivity(
-    @Arg("data", () => ActivityInput) data: ActivityInput
+    @Arg("data", () => UpdateActivityInput) data: UpdateActivityInput
   ): Promise<Activity | null> {
     const activity = await Activity.findOne({ where: { id: data.id } });
     if (!activity) return null;
 
-    if (data.title !== undefined) { activity.title = data.title };
-    if (data.quantity !== undefined) { activity.quantity = data.quantity };
-    if (data.date !== undefined) { activity.date = new Date(data.date) };
-    if (data.co2_equivalent !== undefined) { activity.co2_equivalent = data.co2_equivalent };
+    if (data.title !== undefined) {
+      activity.title = data.title;
+    }
+    if (data.quantity !== undefined) {
+      activity.quantity = data.quantity;
+    }
+    if (data.date !== undefined) {
+      activity.date = new Date(data.date);
+    }
+    if (data.co2_equivalent !== undefined) {
+      activity.co2_equivalent = data.co2_equivalent;
+    }
 
     if (data.user_id !== undefined) {
       const user = await User.findOne({ where: { id: data.user_id } });
@@ -97,4 +131,4 @@ export default class ActivityResolver {
     await activity.remove();
     return true;
   }
-} 
+}

--- a/server/src/resolvers/ActivityResolver.ts
+++ b/server/src/resolvers/ActivityResolver.ts
@@ -58,6 +58,15 @@ export class UpdateActivityInput {
   type_id?: number;
 }
 
+@InputType()
+class ActivityFilterInput {
+  @Field(() => Int)
+  user_id: number;
+
+  @Field(() => Int, { nullable: true })
+  category_id?: number;
+}
+
 @Resolver()
 export default class ActivityResolver {
   @Query(() => [Activity])
@@ -70,6 +79,26 @@ export default class ActivityResolver {
     @Arg("id", () => Int) id: number
   ): Promise<Activity | null> {
     return await Activity.findOne({ where: { id } });
+  }
+
+  @Query(() => [Activity])
+  async getActivitiesByUserIdAndFilters(
+    @Arg("data", () => ActivityFilterInput) data: ActivityFilterInput
+  ): Promise<Activity[]> {
+    const { user_id, category_id } = data;
+    const user = await User.findOne({ where: { id: user_id } });
+    if (!user) throw new Error("User not found");
+
+    const whereClause: {
+      user: { id: number };
+      type?: { category: { id: number } };
+    } = { user: { id: user_id } };
+
+    if (category_id !== undefined) {
+      whereClause.type = { category: { id: category_id } };
+    }
+
+    return await Activity.find({ where: whereClause });
   }
 
   @Mutation(() => Activity)

--- a/server/src/resolvers/ActivityResolver.ts
+++ b/server/src/resolvers/ActivityResolver.ts
@@ -61,12 +61,14 @@ export class UpdateActivityInput {
 @Resolver()
 export default class ActivityResolver {
   @Query(() => [Activity])
-  async activities(): Promise<Activity[]> {
+  async getAllActivities(): Promise<Activity[]> {
     return await Activity.find();
   }
 
   @Query(() => Activity, { nullable: true })
-  async activity(@Arg("id", () => Int) id: number): Promise<Activity | null> {
+  async getActivityById(
+    @Arg("id", () => Int) id: number
+  ): Promise<Activity | null> {
     return await Activity.findOne({ where: { id } });
   }
 

--- a/server/src/resolvers/AvatarResolver.ts
+++ b/server/src/resolvers/AvatarResolver.ts
@@ -20,7 +20,7 @@ export default class AvatarResolver {
     return Avatar.find();
   }
   @Query(() => [Avatar])
-  async getAvatar(@Arg("id", () => Int) id: number): Promise<Avatar> {
+  async getAvatarById(@Arg("id", () => Int) id: number): Promise<Avatar> {
     const avatar = await Avatar.findOneByOrFail({ id });
     return avatar;
   }

--- a/server/src/resolvers/CategoryResolver.ts
+++ b/server/src/resolvers/CategoryResolver.ts
@@ -1,32 +1,29 @@
-import { Resolver, Query, Arg, Int } from "type-graphql";
+import { Arg, Int, Query, Resolver } from "type-graphql";
 import Category from "../entities/Category";
 
-/**
- * TODO: Connect to ADEME API for real data
- */
 @Resolver()
 export default class CategoryResolver {
-  
   @Query(() => [Category])
-  async categories(): Promise<Category[]> {
-    // TODO: Replace with ADEME API call
+  async getAllCategories(): Promise<Category[]> {
+    // TODO: Replace with ADEME API call > NO that would be too muck API calls. We just need to seed the DB once
     return [
       { id: 1, title: "Transport" },
       { id: 2, title: "Alimentation" },
-      { id: 3, title: "Énergie" }
+      { id: 3, title: "Énergie" },
     ] as Category[];
   }
 
-  
   @Query(() => Category, { nullable: true })
-  async category(@Arg("id", () => Int) id: number): Promise<Category | null> {
-    // TODO: Replace with ADEME API call
+  async getCategoryById(
+    @Arg("id", () => Int) id: number
+  ): Promise<Category | null> {
+    // TODO: Replace with ADEME API call > NO that would be too muck API calls. We just need to seed the DB once
     const categories = [
       { id: 1, title: "Transport" },
       { id: 2, title: "Alimentation" },
-      { id: 3, title: "Énergie" }
+      { id: 3, title: "Énergie" },
     ] as Category[];
-    
-    return categories.find(cat => cat.id === id) || null;
+
+    return categories.find((cat) => cat.id === id) || null;
   }
-} 
+}

--- a/server/src/resolvers/CategoryResolver.ts
+++ b/server/src/resolvers/CategoryResolver.ts
@@ -5,25 +5,13 @@ import Category from "../entities/Category";
 export default class CategoryResolver {
   @Query(() => [Category])
   async getAllCategories(): Promise<Category[]> {
-    // TODO: Replace with ADEME API call > NO that would be too muck API calls. We just need to seed the DB once
-    return [
-      { id: 1, title: "Transport" },
-      { id: 2, title: "Alimentation" },
-      { id: 3, title: "Énergie" },
-    ] as Category[];
+    return await Category.find();
   }
 
   @Query(() => Category, { nullable: true })
   async getCategoryById(
     @Arg("id", () => Int) id: number
   ): Promise<Category | null> {
-    // TODO: Replace with ADEME API call > NO that would be too muck API calls. We just need to seed the DB once
-    const categories = [
-      { id: 1, title: "Transport" },
-      { id: 2, title: "Alimentation" },
-      { id: 3, title: "Énergie" },
-    ] as Category[];
-
-    return categories.find((cat) => cat.id === id) || null;
+    return await Category.findOne({ where: { id } });
   }
 }

--- a/server/src/resolvers/InteractionResolver.ts
+++ b/server/src/resolvers/InteractionResolver.ts
@@ -1,22 +1,20 @@
 import { Field, InputType, Int, Resolver } from "type-graphql";
 import Interaction from "../entities/Interaction";
-import Activity from "../entities/Activity";
 
 @InputType()
 export class InteractionInput {
-    @Field(() => Int)
-    user_id: number;
+  @Field(() => Int)
+  user_id: number;
 
-    @Field(() => Int)
-    activity_id: number;
+  @Field(() => Int)
+  activity_id: number;
 
-    @Field(() => String)
-    comment: string;
+  @Field(() => String)
+  comment: string;
 
-    @Field(() => Date)
-    comment_date: Date;
+  @Field(() => Date)
+  comment_date: Date;
 }
 
 @Resolver(Interaction)
-export default class InteractionResolver {
-}
+export default class InteractionResolver {}

--- a/server/src/resolvers/TypeResolver.ts
+++ b/server/src/resolvers/TypeResolver.ts
@@ -5,35 +5,18 @@ import Type from "../entities/Type";
 export default class TypeResolver {
   @Query(() => [Type])
   async getAllTypes(): Promise<Type[]> {
-    // TODO: Replace with ADEME API call > NO that would be too muck API calls. We just need to seed the DB once
-    return [
-      { id: 1, title: "Voiture essence", quantity_unit: "km", category_id: 1 },
-      { id: 2, title: "Voiture diesel", quantity_unit: "km", category_id: 1 },
-      {
-        id: 3,
-        title: "Transport en commun",
-        quantity_unit: "km",
-        category_id: 1,
-      },
-    ] as Type[];
+    return await Type.find();
+  }
+
+  @Query(() => [Type])
+  async getTypesByCategoryId(
+    @Arg("categoryId", () => Int) categoryId: number
+  ): Promise<Type[]> {
+    return await Type.find({ where: { category_id: categoryId } });
   }
 
   @Query(() => Type, { nullable: true })
-  async type(@Arg("id", () => Int) id: number): Promise<Type | null> {
-    // TODO: Replace with ADEME API call > NO that would be too muck API calls. We just need to seed the DB once
-    const types = [
-      { id: 1, title: "Voiture essence", quantity_unit: "km", category_id: 1 },
-      { id: 2, title: "Voiture diesel", quantity_unit: "km", category_id: 1 },
-      {
-        id: 3,
-        title: "Transport en commun",
-        quantity_unit: "km",
-        category_id: 1,
-      },
-    ] as Type[];
-
-    return types.find((type) => type.id === id) || null;
+  async getTypeById(@Arg("id", () => Int) id: number): Promise<Type | null> {
+    return await Type.findOne({ where: { id } });
   }
-
-  // TODO: Add mutations when needed for admin purposes ?
 }

--- a/server/src/resolvers/TypeResolver.ts
+++ b/server/src/resolvers/TypeResolver.ts
@@ -1,33 +1,38 @@
-import { Resolver, Query, Arg, Int } from "type-graphql";
+import { Arg, Int, Query, Resolver } from "type-graphql";
 import Type from "../entities/Type";
 
-/**
- * TODO: Connect to ADEME API for real data
- */
 @Resolver()
 export default class TypeResolver {
-  
   @Query(() => [Type])
-  async types(): Promise<Type[]> {
-    // TODO: Replace with ADEME API call
+  async getAllTypes(): Promise<Type[]> {
+    // TODO: Replace with ADEME API call > NO that would be too muck API calls. We just need to seed the DB once
     return [
       { id: 1, title: "Voiture essence", quantity_unit: "km", category_id: 1 },
       { id: 2, title: "Voiture diesel", quantity_unit: "km", category_id: 1 },
-      { id: 3, title: "Transport en commun", quantity_unit: "km", category_id: 1 }
+      {
+        id: 3,
+        title: "Transport en commun",
+        quantity_unit: "km",
+        category_id: 1,
+      },
     ] as Type[];
   }
 
- 
   @Query(() => Type, { nullable: true })
   async type(@Arg("id", () => Int) id: number): Promise<Type | null> {
-    // TODO: Replace with ADEME API call
+    // TODO: Replace with ADEME API call > NO that would be too muck API calls. We just need to seed the DB once
     const types = [
       { id: 1, title: "Voiture essence", quantity_unit: "km", category_id: 1 },
       { id: 2, title: "Voiture diesel", quantity_unit: "km", category_id: 1 },
-      { id: 3, title: "Transport en commun", quantity_unit: "km", category_id: 1 }
+      {
+        id: 3,
+        title: "Transport en commun",
+        quantity_unit: "km",
+        category_id: 1,
+      },
     ] as Type[];
-    
-    return types.find(type => type.id === id) || null;
+
+    return types.find((type) => type.id === id) || null;
   }
 
   // TODO: Add mutations when needed for admin purposes ?

--- a/server/src/resolvers/UserResolver.ts
+++ b/server/src/resolvers/UserResolver.ts
@@ -10,12 +10,11 @@ import {
   Resolver,
 } from "type-graphql";
 
-import { AvatarInput } from "./AvatarResolver";
-import User from "../entities/User";
-import UserService from "../services/UserService";
-
 import type Avatar from "../entities/Avatar";
+import User from "../entities/User";
 import type { UserServiceInterface } from "../services/UserService";
+import UserService from "../services/UserService";
+import { AvatarInput } from "./AvatarResolver";
 
 @InputType()
 export class NewUserInput {
@@ -101,7 +100,7 @@ export default class UserResolver {
   }
 
   @Query(() => User)
-  async getUser(@Arg("id", () => Int) id: number) {
+  async getUserById(@Arg("id", () => Int) id: number) {
     const user = await User.findOneByOrFail({ id });
     return user;
   }

--- a/server/src/resolvers/__tests__/ActivityResolver.test.ts
+++ b/server/src/resolvers/__tests__/ActivityResolver.test.ts
@@ -1,0 +1,309 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import {
+  createMockActivity,
+  createMockCategory,
+  createMockType,
+  createMockUser,
+} from "../../__tests__/helpers";
+
+import Activity from "../../entities/Activity";
+import type Category from "../../entities/Category";
+import type Type from "../../entities/Type";
+import User from "../../entities/User";
+
+import ActivityResolver from "../ActivityResolver";
+
+describe("ActivityResolver", () => {
+  let activityResolver: ActivityResolver;
+  let mockUser: User;
+  let mockActivity1: Activity;
+  let mockActivity2: Activity;
+  let mockActivity3: Activity;
+  let mockCategory1: Category;
+  let mockCategory2: Category;
+  let mockType1: Type;
+  let mockType2: Type;
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Initialize resolver
+    activityResolver = new ActivityResolver();
+
+    // Create mock categories
+    mockCategory1 = createMockCategory({
+      id: 1,
+      title: "Transport",
+    });
+
+    mockCategory2 = createMockCategory({
+      id: 2,
+      title: "Alimentation",
+    });
+
+    // Create mock types
+    mockType1 = createMockType({
+      id: 1,
+      title: "Voiture",
+      quantity_unit: "km",
+      category_id: 1,
+      category: mockCategory1,
+    });
+
+    mockType2 = createMockType({
+      id: 2,
+      title: "Viande",
+      quantity_unit: "kg",
+      category_id: 2,
+      category: mockCategory2,
+    });
+
+    // Create mock user
+    mockUser = createMockUser({
+      id: 1,
+      email: "test@example.com",
+      first_name: "John",
+      last_name: "Doe",
+    });
+
+    // Create mock activities
+    mockActivity1 = createMockActivity({
+      id: 1,
+      title: "Trip to work",
+      quantity: 15.5,
+      date: new Date("2024-01-15"),
+      co2_equivalent: 3.2,
+      user: mockUser,
+      type: mockType1,
+    });
+
+    mockActivity2 = createMockActivity({
+      id: 2,
+      title: "Lunch meat",
+      quantity: 0.5,
+      date: new Date("2024-01-16"),
+      co2_equivalent: 2.8,
+      user: mockUser,
+      type: mockType2,
+    });
+
+    mockActivity3 = createMockActivity({
+      id: 3,
+      title: "Shopping trip",
+      quantity: 8.0,
+      date: new Date("2024-01-17"),
+      co2_equivalent: 1.7,
+      user: mockUser,
+      type: mockType1,
+    });
+  });
+
+  describe("getActivitiesByUserIdAndFilters", () => {
+    it("should return all activities for a user when no category filter is provided", async () => {
+      // Arrange
+      const filterData = {
+        user_id: 1,
+      };
+
+      const mockActivities = [mockActivity1, mockActivity2, mockActivity3];
+
+      // Mock User.findOne
+      jest.spyOn(User, "findOne").mockResolvedValue(mockUser);
+      // Mock Activity.find
+      jest.spyOn(Activity, "find").mockResolvedValue(mockActivities);
+
+      // Act
+      const result = await activityResolver.getActivitiesByUserIdAndFilters(
+        filterData
+      );
+
+      // Assert
+      expect(User.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(Activity.find).toHaveBeenCalledWith({
+        where: { user: { id: 1 } },
+      });
+      expect(result).toEqual(mockActivities);
+      expect(result).toHaveLength(3);
+    });
+
+    it("should return filtered activities by category when category_id is provided", async () => {
+      // Arrange
+      const filterData = {
+        user_id: 1,
+        category_id: 1, // Transport category
+      };
+
+      const filteredActivities = [mockActivity1, mockActivity3]; // Both are transport activities
+
+      jest.spyOn(User, "findOne").mockResolvedValue(mockUser);
+      jest.spyOn(Activity, "find").mockResolvedValue(filteredActivities);
+
+      // Act
+      const result = await activityResolver.getActivitiesByUserIdAndFilters(
+        filterData
+      );
+
+      // Assert
+      expect(User.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(Activity.find).toHaveBeenCalledWith({
+        where: {
+          user: { id: 1 },
+          type: { category: { id: 1 } },
+        },
+      });
+      expect(result).toEqual(filteredActivities);
+      expect(result).toHaveLength(2);
+    });
+
+    it("should return empty array when user has no activities for the specified category", async () => {
+      // Arrange
+      const filterData = {
+        user_id: 1,
+        category_id: 3, // Non-existent category
+      };
+
+      jest.spyOn(User, "findOne").mockResolvedValue(mockUser);
+      jest.spyOn(Activity, "find").mockResolvedValue([]);
+
+      // Act
+      const result = await activityResolver.getActivitiesByUserIdAndFilters(
+        filterData
+      );
+
+      // Assert
+      expect(User.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(Activity.find).toHaveBeenCalledWith({
+        where: {
+          user: { id: 1 },
+          type: { category: { id: 3 } },
+        },
+      });
+      expect(result).toEqual([]);
+      expect(result).toHaveLength(0);
+    });
+
+    it("should throw an error when user is not found", async () => {
+      // Arrange
+      const filterData = {
+        user_id: 999, // Non-existent user
+      };
+
+      jest.spyOn(User, "findOne").mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        activityResolver.getActivitiesByUserIdAndFilters(filterData)
+      ).rejects.toThrow("User not found");
+
+      expect(User.findOne).toHaveBeenCalledWith({ where: { id: 999 } });
+      expect(Activity.find).not.toHaveBeenCalled();
+    });
+
+    it("should handle undefined category_id correctly", async () => {
+      // Arrange
+      const filterData = {
+        user_id: 1,
+        category_id: undefined,
+      };
+
+      const mockActivities = [mockActivity1, mockActivity2];
+
+      jest.spyOn(User, "findOne").mockResolvedValue(mockUser);
+      jest.spyOn(Activity, "find").mockResolvedValue(mockActivities);
+
+      // Act
+      const result = await activityResolver.getActivitiesByUserIdAndFilters(
+        filterData
+      );
+
+      // Assert
+      expect(User.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(Activity.find).toHaveBeenCalledWith({
+        where: { user: { id: 1 } },
+      });
+      expect(result).toEqual(mockActivities);
+    });
+
+    it("should handle category_id value of 0 correctly", async () => {
+      // Arrange
+      const filterData = {
+        user_id: 1,
+        category_id: 0,
+      };
+
+      jest.spyOn(User, "findOne").mockResolvedValue(mockUser);
+      jest.spyOn(Activity, "find").mockResolvedValue([]);
+
+      // Act
+      const result = await activityResolver.getActivitiesByUserIdAndFilters(
+        filterData
+      );
+
+      // Assert
+      expect(User.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(Activity.find).toHaveBeenCalledWith({
+        where: {
+          user: { id: 1 },
+          type: { category: { id: 0 } },
+        },
+      });
+      expect(result).toEqual([]);
+    });
+
+    it("should verify that the correct where clause is built when both filters are provided", async () => {
+      // Arrange
+      const filterData = {
+        user_id: 5,
+        category_id: 2,
+      };
+
+      const mockUserDifferent = createMockUser({
+        id: 5,
+        email: "different@example.com",
+      });
+      const filteredActivities = [mockActivity2];
+
+      jest.spyOn(User, "findOne").mockResolvedValue(mockUserDifferent);
+      jest.spyOn(Activity, "find").mockResolvedValue(filteredActivities);
+
+      // Act
+      const result = await activityResolver.getActivitiesByUserIdAndFilters(
+        filterData
+      );
+
+      // Assert
+      expect(User.findOne).toHaveBeenCalledWith({ where: { id: 5 } });
+      expect(Activity.find).toHaveBeenCalledWith({
+        where: {
+          user: { id: 5 },
+          type: { category: { id: 2 } },
+        },
+      });
+      expect(result).toEqual(filteredActivities);
+    });
+
+    it("should handle database errors gracefully", async () => {
+      // Arrange
+      const filterData = {
+        user_id: 1,
+      };
+
+      jest.spyOn(User, "findOne").mockResolvedValue(mockUser);
+      jest
+        .spyOn(Activity, "find")
+        .mockRejectedValue(new Error("Database connection failed"));
+
+      // Act & Assert
+      await expect(
+        activityResolver.getActivitiesByUserIdAndFilters(filterData)
+      ).rejects.toThrow("Database connection failed");
+
+      expect(User.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(Activity.find).toHaveBeenCalledWith({
+        where: { user: { id: 1 } },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
> Quickly describe the context and purpose of your PR.

This pull request makes significant changes to the backend entity relationships and GraphQL resolvers, focusing on replacing hardcoded data with database queries, clarifying entity relationships, and expanding the API's querying and mutation capabilities. The changes also include new test helpers and refactoring for consistency and maintainability.

## Changes Made
> Details changes you made
**feat**:
- Added filtering capabilities to the `ActivityResolver`, allowing queries for activities by user and category. Also, separated input types for creating and updating activities for better mutation handling.

**fix**:
- Updated resolvers for `Activity`, `Category`, and `Type` to replace hardcoded data with real database queries, ensuring all data is fetched from the database. Added new queries such as `getTypesByCategoryId` and improved naming for clarity (e.g., `getAllActivities`, `getCategoryById`).

**refactor**:
- Refactored entity relationships for `Activity`, `Type`, and `Category` to clarify associations, such as changing `Type.categories` (array) to `Type.category` (single reference) and updating related decorators and fields accordingly. Also, made `Activity.interactions` nullable and adjusted field types for better schema accuracy.
- Refactored imports for consistency across entity and resolver files, and updated method and variable names for clarity (e.g., `getUserById`, `getAvatarById`).

**test**:
- Introduced new mock entity creators (`createMockCategory`, `createMockType`, `createMockActivity`) in the test helpers to facilitate easier and more accurate unit testing.

## How to test ? 
> Provide steps to test or validate the changes.
- [ ] navigate to the apollo server
- [ ] Try out the different queries and mutations in the activity resolver to check if everything seems fine